### PR TITLE
Fix minimum node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### 1.1.1
+
+- Fix minimum node versions
+
 ## 1.1.0
 
 - New `platform` name - Refer to README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       },
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-        "node": "^18.20.4 || ^20.16.0 || ^22.6.0"
+        "node": "^18.20.4 || ^20.15.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-wiser2",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-wiser2",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-wiser2",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Wiser2 (SpaceLogic C-Bus Home Controller) plugin for homebridge: https://github.com/homebridge/homebridge",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://github.com/xJARiD/homebridge-wiser2/issues"
   },
   "engines": {
-    "node": "^18.20.4 || ^20.16.0 || ^22.6.0",
+    "node": "^18.20.4 || ^20.15.0",
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "dependencies": {


### PR DESCRIPTION
Set node version to ^20.15.0 as this is what homebridge defaults to.